### PR TITLE
Add default template for empty truffle box

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache \
 RUN npm install -g truffle
 
 COPY docker/docker-truffle-entrypoint.sh /usr/local/bin/docker-entrypoint
+COPY docker/template/truffle.js /tmp/truffle.js
 RUN chmod +x /usr/local/bin/docker-entrypoint
 
 WORKDIR /srv/truffle

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ console:
 test: ## Run the test suite
 	$(DOCKER_COMPOSE) exec truffle truffle test
 
-.PHONY: kill install reset start stop clean no-docker
+.PHONY: build kill install reset start stop no-docker compile migrate console test
 
 .DEFAULT_GOAL := help
 help:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   ganache:
     image: trufflesuite/ganache-cli
     ports:
-      - "7545:7545"
+      - "7545:8545"
 
   truffle:
     build:

--- a/docker/docker-truffle-entrypoint.sh
+++ b/docker/docker-truffle-entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 if [ ! -f truffle.js ]; then
     rm .gitkeep
 	truffle init
+	mv -f /tmp/truffle.js ./truffle.js
 fi
 
 exec docker-entrypoint

--- a/docker/template/truffle.js
+++ b/docker/template/truffle.js
@@ -1,0 +1,25 @@
+/*
+ * NB: since truffle-hdwallet-provider 0.0.5 you must wrap HDWallet providers in a
+ * function when declaring them. Failure to do so will cause commands to hang. ex:
+ * ```
+ * mainnet: {
+ *     provider: function() {
+ *       return new HDWalletProvider(mnemonic, 'https://mainnet.infura.io/<infura-key>')
+ *     },
+ *     network_id: '1',
+ *     gas: 4500000,
+ *     gasPrice: 10000000000,
+ *   },
+ */
+
+module.exports = {
+  // See <http://truffleframework.com/docs/advanced/configuration>
+  // to customize your Truffle configuration!
+  networks: {
+    development: {
+      host: "ganache",
+      port: 8545,
+      network_id: "*" // Match any network id
+    }
+  }
+};


### PR DESCRIPTION
## Description
When `./truffle/` is empty, the docker-entrypoint create a default truffle box. There is no configuration for ganache by default and `make console` can't works.

## Related Issue
#1 

## How Has This Been Tested?
Empty project and README step by step.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
